### PR TITLE
Snap: Fix-up application icon lookup

### DIFF
--- a/packaging/snap/snapcraft.yaml
+++ b/packaging/snap/snapcraft.yaml
@@ -28,4 +28,10 @@ parts:
     stage-packages:
       - libqt5xml5
     after: [desktop-qt5]
+    override-prime: |
+      set -eu
 
+      snapcraftctl prime
+
+      # Fix-up application icon lookup
+      sed --in-place 's|^Icon=.*|Icon=\${SNAP}/meta/gui/icon.png|' usr/share/applications/heimer.desktop


### PR DESCRIPTION
Currently snapd/snapcraft doesn't do much on making the application icon
lookup works without manually patching the desktop entry.  This patch
does the patching in the prime step using a scriptlet.

Fixes #14.

![default](https://user-images.githubusercontent.com/13408130/45317475-bbffd080-b56c-11e8-804b-e8db372b08f4.png)

Refer-to: Application icon doesn't work in the launcher - snapcraft -
snapcraft.io
<https://forum.snapcraft.io/t/application-icon-doesnt-work-in-the-launcher/7292/7>
Refer-to: Scriptlets - doc - snapcraft.io
<https://forum.snapcraft.io/t/scriptlets/4892>
Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>