### PR TITLE
Readme fix: build dependency typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Snap is the recommended way to install Heimer on Linux.
 
 ## Building the project
 
-Currently the build depends on `Qt5` only (`qt5-default`, `qttools5-dev-tools`, `qttools5-dev` packages on Ubuntu).
+Currently the build depends on `Qt5` only (`qt5-default`, `qttools5-dev-tools`, `qttools5-dev`, `libqt5svg5-dev` packages on Ubuntu).
 
 The "official" build system for Linux is `CMake` although `qmake` project files are also provided.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Snap is the recommended way to install Heimer on Linux.
 
 ## Building the project
 
-Currently the build depends on `Qt5` only (`qt5-default`, `qttools5-dev-tools`, `qttools-dev` packages on Ubuntu).
+Currently the build depends on `Qt5` only (`qt5-default`, `qttools5-dev-tools`, `qttools5-dev` packages on Ubuntu).
 
 The "official" build system for Linux is `CMake` although `qmake` project files are also provided.
 


### PR DESCRIPTION
Hello there,

I was going through the process of building the app, and one of the dependencies was not found by apt. I believe it is because '5' was missing from 

I'm running on found on Ubuntu 20.04, so I'm not sure if it may be available in older versions.