### PR TITLE
Screen the flash back caused by the absence of a file

### DIFF
--- a/src/mediator.cpp
+++ b/src/mediator.cpp
@@ -1,4 +1,4 @@
-// This file is part of Heimer.
+﻿// This file is part of Heimer.
 // Copyright (C) 2018 Jussi Lind <jussi.lind@iki.fi>
 //
 // Heimer is free software: you can redistribute it and/or modify
@@ -493,8 +493,8 @@ bool Mediator::openMindMap(QString fileName)
     assert(m_editorData);
 
     try {
-        m_editorScene = std::make_unique<EditorScene>();
         m_editorData->loadMindMapData(fileName);
+        m_editorScene = std::make_unique<EditorScene>();
         initializeView();
         addExistingGraphToScene();
         connectGraphToUndoMechanism();


### PR DESCRIPTION
Steps:

1. Save the current flowchart

2. Exit the software

3. Delete locally saved files

4. Open the file just deleted with recent file

5. The software pop-up file is wrong. Click arbitrarily on the window after closing the pop-up window.

6. Software flash back