### PR TITLE
Add WITH_QT6 option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,9 +96,14 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(QT_MIN_VER 5.9.5) # The version in Ubuntu 18.04 LTS
 # This is what Qt Creator 4.13.2 would generate
-find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
-find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Xml Widgets LinguistTools Svg Test Network REQUIRED)
-
+OPTION(WITH_QT6 "Enable Qt 6" OFF)
+if (WITH_QT6)
+    find_package(QT NAMES Qt6 COMPONENTS Core REQUIRED)
+    find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Xml Widgets LinguistTools Svg Test Network REQUIRED)
+else()
+    find_package(QT NAMES Qt5 COMPONENTS Core REQUIRED)
+    find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Xml Widgets LinguistTools Svg Test Network REQUIRED)
+endif()
 # Install paths depend on the build type and target platform
 setup_install_targets()
 


### PR DESCRIPTION
On systems with both qt5 and qt6 installed, cmake will use qt6 by default. Sugestion on adding an option WITH_QT6=OFF by default. I've take this from https://github.com/hluk/CopyQ/blob/master/CMakeLists.txt where qt6 is still experimental so this option is turned off.

I'm maintaining FreeBSD port(https://www.freshports.org/graphics/heimer/) and it builds fine under poudriere jails because port only ask for qt5, but it fails on my local account because I have both qt5 and qt6 installed.

I'm not a programmer, so please optimize or correct my sugestion.

Cheers,
Nuno Teixeira